### PR TITLE
Add graphviz to binder environment so schematics render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# gdsfactory binder
+# GDS Factory Binder
 
-Launch [binder jupyter notebook environment](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD) for gdsfactory training
+Click to open GDS Factory in a [binder Jupyter Lab environment](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD).
 
-Includes open source pdks:
+Binder may take a moment to launch.
+
+Check out the notebooks in the *Notebooks* folder to learn how to design chips with GDS Factory.
+
+
+**Notes**
+
+The following open source PDKs are installed in the environment:
 
 - [SiEPIC EBeam UBCPDK](https://gdsfactory.github.io/ubc/README.html)
 - [skywater130](https://gdsfactory.github.io/skywater130/README.html)
-
-References:
-
-- https://discourse.jupyter.org/t/how-to-reduce-mybinder-org-repository-startup-time/4956

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Binder may take a moment to launch.
 
 Check out the notebooks in the *Notebooks* folder to learn how to design chips with GDS Factory.
 
+## Resources
+- [GDS Factory docs](https://gdsfactory.github.io/gdsfactory/).
+- Do more with [GDS Factory+](https://gdsfactory.com/) for enterprises.
 
 **Notes**
 

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+graphviz


### PR DESCRIPTION
Adds apt.txt file to install graphviz library in the Binder environment.

Graphviz must be installed into the environment (and not just from pypi) so that the schematic in 10_schematic.ipynb renders and does not error.

Screenshot post update:

<img width="1088" alt="Screenshot 2025-05-28 at 12 29 34 PM" src="https://github.com/user-attachments/assets/2364adf1-bbd4-4a7f-bd80-0f04afc805f4" />

Also updates the README in case a user stumbles on it.

## Summary by Sourcery

Install Graphviz into the Binder environment to support schematic rendering and update documentation with clearer launch instructions and resources.

Enhancements:
- Enable schematic rendering in Binder notebooks by installing system-level Graphviz

Build:
- Add apt.txt to install Graphviz in the Binder environment

Documentation:
- Revise README with updated Binder launch instructions, resources section, and PDK listings